### PR TITLE
Add a hint to set IBMCLOUD_TRACE flag

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -29,6 +29,8 @@ subcollection: hs-crypto
 General problems with using {{site.data.keyword.cloud}} {{site.data.keyword.hscrypto}} might include providing the correct headers or credentials when you interact with the API. In many cases, you can recover from these problems by following a few easy steps.
 {: shortdesc}
 
+**Hint**: When using `ibmcloud` cli, to get detailed error message, set `IBMCLOUD_TRACE=true`.
+
 ## Error occurred when deleting an initialized service instance
 {: #troubleshoot-delete-instance}
 {: troubleshoot}


### PR DESCRIPTION
Since the cli usually doesn't print a detailed messages when an error is
occurred, a user needs to set IBMCLOUD_TRACE for a verbose error
message. This commit adds a hint to help readers to better understand
error messages.